### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,6 @@
+bom: production_v2.1/BOM_v2.1.csv
+gerbers: gerber_v2.1/
+site: https://cast.otter.jetzt/
+eda:
+  type: kicad
+  pcb: OtterCastAudioV2.kicad_pcb


### PR DESCRIPTION
This adds the file necessary to put up a Kitspace project. If you are happy to have a page for this project, simply merge. If you have any concerns, let me know. 

preview: http://add-ottercast.preview.kitspace.org/boards/github.com/kitspace-forks/OtterCastAudioV2/ 

Some things to consider regarding BOM:

- There is no quantity column so quantity is is inferred from references. This may be more brittle than adding an explicit quantity column.
- There are "dnp" and other words in the LCSC column. The way this is currently parsed by Kitspace it looks like it has all the parts, but when you go to order it will adding 20 parts as failed. 